### PR TITLE
Add methods that add aliases to QUnitConvertor object

### DIFF
--- a/QUnitConversion/qaliasdictionary.h
+++ b/QUnitConversion/qaliasdictionary.h
@@ -47,10 +47,10 @@ public:
      * @param name name which will be returned if an alias requested
      * @param alias alias for the given name
      */
-    void addAlias(const String &name, const String &alias)
+    void addAlias(String name, String alias)
     {
-        m_aliases.insert(alias, name);
-        m_names.insert(name);
+        m_aliases.insert(std::move(alias), name);
+        m_names.insert(std::move(name));
     }
     /**
      * @brief Checks if a dictionary contains name for the given alias

--- a/QUnitConversion/qaliasdictionary.h
+++ b/QUnitConversion/qaliasdictionary.h
@@ -15,11 +15,6 @@ class QAliasDictionary
 {
 public:
     /**
-     * @brief Default constructor
-     */
-    QAliasDictionary() = default;
-
-    /**
      * @brief Gets name by alias
      * @param alias to get name
      * @return string containing name corresponding to the given alias

--- a/QUnitConversion/qunitconvertor.cpp
+++ b/QUnitConversion/qunitconvertor.cpp
@@ -93,6 +93,11 @@ void QUnitConvertor::setAliases(QAliasDictionary<QString> aliases)
     m_aliases = std::move(aliases);
 }
 
+void QUnitConvertor::addAlias(QString name, QString alias)
+{
+    m_aliases.addAlias(std::move(name), std::move(alias));
+}
+
 void QUnitConvertor::clearAliases()
 {
     m_aliases.clear();

--- a/QUnitConversion/qunitconvertor.cpp
+++ b/QUnitConversion/qunitconvertor.cpp
@@ -88,6 +88,11 @@ QStringList QUnitConvertor::units(const QString &family) const
     return m_familiesByUnit.keys(family);
 }
 
+void QUnitConvertor::setAliases(QAliasDictionary<QString> aliases)
+{
+    m_aliases = std::move(aliases);
+}
+
 void QUnitConvertor::clearAliases()
 {
     m_aliases.clear();

--- a/QUnitConversion/qunitconvertor.cpp
+++ b/QUnitConversion/qunitconvertor.cpp
@@ -95,7 +95,7 @@ void QUnitConvertor::setAliases(QAliasDictionary<QString> aliases)
 
 void QUnitConvertor::addAlias(QString name, QString alias)
 {
-    m_aliases.addAlias(std::move(name), std::move(alias));
+    m_aliases.addAlias(name, alias);
 }
 
 void QUnitConvertor::clearAliases()

--- a/QUnitConversion/qunitconvertor.h
+++ b/QUnitConversion/qunitconvertor.h
@@ -95,6 +95,8 @@ public:
      */
     QStringList units(const QString &family) const;
 
+    void setAliases(QAliasDictionary<QString> aliases);
+
 
     /**
      * @brief Removes all alias rules

--- a/QUnitConversion/qunitconvertor.h
+++ b/QUnitConversion/qunitconvertor.h
@@ -96,6 +96,7 @@ public:
     QStringList units(const QString &family) const;
 
     void setAliases(QAliasDictionary<QString> aliases);
+    void addAlias(QString name, QString alias);
 
 
     /**

--- a/QUnitConversion/qunitconvertor.h
+++ b/QUnitConversion/qunitconvertor.h
@@ -95,7 +95,14 @@ public:
      */
     QStringList units(const QString &family) const;
 
+    /**
+     * @brief adds aliases from the object QAliasDictionary
+     */
     void setAliases(QAliasDictionary<QString> aliases);
+
+    /**
+     * @brief adds one alias
+     */
     void addAlias(QString name, QString alias);
 
 

--- a/tests/qunitconvertortests.cpp
+++ b/tests/qunitconvertortests.cpp
@@ -117,10 +117,17 @@ void QUnitConvertorTests::setAliasesTest()
     QUnitConvertor convertor;
     convertor.setAliases(aliases);
 
-    QVERIFY(convertor.m_aliases.name("name") == "name");
-    QVERIFY(convertor.m_aliases.name("alias1") == "name");
-    QVERIFY(convertor.m_aliases.name("alias2") == "name");
-    QVERIFY(convertor.m_aliases.name("alias3") == "name");
+    QVERIFY(convertor.unitName("name") == "name");
+    QVERIFY(convertor.unitName("alias1") == "name");
+    QVERIFY(convertor.unitName("alias2") == "name");
+    QVERIFY(convertor.unitName("alias3") == "name");
 
 }
+
+//void QUnitConvertorTests::addAliasTest()
+//{
+//    QUnitConvertor convertor;
+//    convertor.addAlias("name", "")
+
+//}
 

--- a/tests/qunitconvertortests.cpp
+++ b/tests/qunitconvertortests.cpp
@@ -110,17 +110,20 @@ void QUnitConvertorTests::addRuleTest()
 void QUnitConvertorTests::setAliasesTest()
 {
     QAliasDictionary<QString> aliases;
-    aliases.addAlias("name", "alias1");
-    aliases.addAlias("name", "alias2");
-    aliases.addAlias("name", "alias3");
+    aliases.addAlias("m", "m");
+    aliases.addAlias("m", "meter");
+    aliases.addAlias("m", "meters");
 
     QUnitConvertor convertor;
+    convertor.addConversionRule(QUnitConversionRule("length", "m", "km", 0.001, 0));
+    QVERIFY(convertor.canConvert("m", "km"));
+    QVERIFY(convertor.canConvert("km", "m"));
+    QVERIFY(!convertor.canConvert("km", "meter"));
+
     convertor.setAliases(aliases);
 
-    QVERIFY(convertor.unitName("name") == "name");
-    QVERIFY(convertor.unitName("alias1") == "name");
-    QVERIFY(convertor.unitName("alias2") == "name");
-    QVERIFY(convertor.unitName("alias3") == "name");
+    QVERIFY(convertor.canConvert("km", "meter"));
+    QVERIFY(convertor.canConvert("km", "meters"));
 
 }
 

--- a/tests/qunitconvertortests.cpp
+++ b/tests/qunitconvertortests.cpp
@@ -1,4 +1,5 @@
 #include "qunitconvertortests.h"
+#include "qaliasdictionary.h"
 
 QUnitConvertorTests::QUnitConvertorTests(QObject *parent) : QObject(parent)
 {
@@ -103,6 +104,23 @@ void QUnitConvertorTests::addRuleTest()
     QVERIFY(convertor.family("m") == "length");
     QVERIFY(convertor.family("km") == "length");
     QVERIFY(convertor.family("mmmmm").isEmpty());
+
+}
+
+void QUnitConvertorTests::setAliasesTest()
+{
+    QAliasDictionary<QString> aliases;
+    aliases.addAlias("name", "alias1");
+    aliases.addAlias("name", "alias2");
+    aliases.addAlias("name", "alias3");
+
+    QUnitConvertor convertor;
+    convertor.setAliases(aliases);
+
+    QVERIFY(convertor.m_aliases.name("name") == "name");
+    QVERIFY(convertor.m_aliases.name("alias1") == "name");
+    QVERIFY(convertor.m_aliases.name("alias2") == "name");
+    QVERIFY(convertor.m_aliases.name("alias3") == "name");
 
 }
 

--- a/tests/qunitconvertortests.cpp
+++ b/tests/qunitconvertortests.cpp
@@ -109,16 +109,16 @@ void QUnitConvertorTests::addRuleTest()
 
 void QUnitConvertorTests::setAliasesTest()
 {
-    QAliasDictionary<QString> aliases;
-    aliases.addAlias("m", "m");
-    aliases.addAlias("m", "meter");
-    aliases.addAlias("m", "meters");
-
     QUnitConvertor convertor;
     convertor.addConversionRule(QUnitConversionRule("length", "m", "km", 0.001, 0));
     QVERIFY(convertor.canConvert("m", "km"));
     QVERIFY(convertor.canConvert("km", "m"));
     QVERIFY(!convertor.canConvert("km", "meter"));
+
+    QAliasDictionary<QString> aliases;
+    aliases.addAlias("m", "m");
+    aliases.addAlias("m", "meter");
+    aliases.addAlias("m", "meters");
 
     convertor.setAliases(aliases);
 
@@ -127,10 +127,23 @@ void QUnitConvertorTests::setAliasesTest()
 
 }
 
-//void QUnitConvertorTests::addAliasTest()
-//{
-//    QUnitConvertor convertor;
-//    convertor.addAlias("name", "")
+void QUnitConvertorTests::addAliasTest()
+{
+    QUnitConvertor convertor;
+    convertor.addConversionRule(QUnitConversionRule("length", "m", "km", 0.001, 0));
 
-//}
+    QAliasDictionary<QString> aliases;
+    aliases.addAlias("m", "m");
+    aliases.addAlias("m", "meter");
+
+    convertor.setAliases(aliases);
+
+    QVERIFY(convertor.canConvert("km", "meter"));
+    QVERIFY(!convertor.canConvert("km", "meters"));
+
+    convertor.addAlias("m", "meters");
+
+    QVERIFY(convertor.canConvert("km", "meters"));
+
+}
 

--- a/tests/qunitconvertortests.h
+++ b/tests/qunitconvertortests.h
@@ -15,7 +15,7 @@ public:
 private slots:
     void addRuleTest();
     void setAliasesTest();
-//    void addAliasTest();
+    void addAliasTest();
 };
 
 #endif // QUNITCONVERTORTESTS_H

--- a/tests/qunitconvertortests.h
+++ b/tests/qunitconvertortests.h
@@ -15,6 +15,7 @@ public:
 private slots:
     void addRuleTest();
     void setAliasesTest();
+//    void addAliasTest();
 };
 
 #endif // QUNITCONVERTORTESTS_H

--- a/tests/qunitconvertortests.h
+++ b/tests/qunitconvertortests.h
@@ -14,6 +14,7 @@ public:
 
 private slots:
     void addRuleTest();
+    void setAliasesTest();
 };
 
 #endif // QUNITCONVERTORTESTS_H


### PR DESCRIPTION
- Add two methods:

> 1. `void setAliases(QAliasDictionary<QString> aliases)` - gets QAliasDictionary object and adds bunch of aliases from it to QUnitConvertor object
> 
> 2.  `void addAlias(QString name, QString alias)` - adds one alias based on input strings to QUnitConvertor object

- Add tests for both methods